### PR TITLE
Use singleton method to register commands

### DIFF
--- a/src/Webpatser/Countries/CountriesServiceProvider.php
+++ b/src/Webpatser/Countries/CountriesServiceProvider.php
@@ -69,7 +69,7 @@ class CountriesServiceProvider extends ServiceProvider {
      */
     protected function registerCommands()
     {
-        $this->app['command.countries.migration'] = $this->app->share(function($app)
+        $this->app->singleton('command.countries.migration', function($app)
         {
             return new MigrationCommand($app);
         });


### PR DESCRIPTION
In Laravel 5.4 the share method has been removed from the container.

As documented in:

- [Upgrade Guide](https://laravel.com/docs/5.4/upgrade#upgrade-5.4.0)
- [Laravel 5.4 Documentation](https://laravel.com/docs/5.4/container#binding-basics)